### PR TITLE
A fix for the handling of special-characters paths on windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 /stamp-h1
 Makefile
 Makefile.in
+/src/win32/xournal.res
+/src/xournal.exe

--- a/src/win32/force_utf8.xml
+++ b/src/win32/force_utf8.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="..." version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/win32/xournal.rc
+++ b/src/win32/xournal.rc
@@ -1,1 +1,3 @@
+#include <winuser.h>
 id ICON "xournal.ico"
+1 RT_MANIFEST "force_utf8.xml"


### PR DESCRIPTION
Fixed the handling of special-characters paths when opening .xoj files on windows. Keep in mind this fix only works for windows version 1903 (May 2019 Update) and above! Older versions will still have trouble with special-characters paths. (The fix was based on this article by microsoft: https://docs.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page ).