### PR TITLE
SourceFourge Bug 5: abort autogen.sh when package config is unavailable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_SEARCH_LIBS([hypot],[m])
 AC_SEARCH_LIBS([gzprintf],[z])
 AC_SEARCH_LIBS([XUngrabButton],[X11])
 
-ifdef([PKG_CHECK_MODULES], [[]], [m4_fatal([No module checker; it may be pkgconf in *nix])])
+ifdef([PKG_CHECK_MODULES], [[]], [m4_fatal([Module checker (pkg-config or pkgconf) is required but does not seem to be installed.])])
 
 pkg_modules="gtk+-2.0 >= 2.10.0 libgnomecanvas-2.0 >= 2.4.0 poppler-glib >= 0.5.4 pangoft2 >= 1.0"
 PKG_CHECK_MODULES(PACKAGE,[$pkg_modules])

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_SEARCH_LIBS([hypot],[m])
 AC_SEARCH_LIBS([gzprintf],[z])
 AC_SEARCH_LIBS([XUngrabButton],[X11])
 
+ifdef([PKG_CHECK_MODULES], [[]], [m4_fatal([No module checker; it may be pkgconf in *nix])])
+
 pkg_modules="gtk+-2.0 >= 2.10.0 libgnomecanvas-2.0 >= 2.4.0 poppler-glib >= 0.5.4 pangoft2 >= 1.0"
 PKG_CHECK_MODULES(PACKAGE,[$pkg_modules])
 CFLAGS="$PACKAGE_CFLAGS $CFLAGS"


### PR DESCRIPTION
https://sourceforge.net/p/xournal/bugs/5/
If autogen is not aborted, then we get obscure errors in the shell in configure:
./configure: line 5716: syntax error near unexpected token `PACKAGE,$pkg_module>
./configure: line 5716: `PKG_CHECK_MODULES(PACKAGE,$pkg_modules)'