### PR TITLE
Sourceforge bug 205: text vertical position relative to cursor

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -3,6 +3,9 @@ name: Makefile ACI
 on:
   push:
     branches: [ "sf-bug-205-position-01" ]
+    
+  workflow_dispatch:
+      { }
 
 jobs:
   build:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -3,10 +3,6 @@ name: Makefile ACI
 on:
   push:
     branches: [ "sf-bug-205-position-01" ]
-  pull_request:
-    branches: [ "none" ]
-  workflow_run:
-    branches: [ "sf-bug-205-position-01" ]
 
 jobs:
   build:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,32 @@
+name: Makefile ACI
+
+on:
+  push:
+    branches: [ "sf-bug-205-position-01" ]
+  pull_request:
+    branches: [ "none" ]
+  workflow_run:
+    branches: [ "sf-bug-205-position-01" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: autogen
+      run: ./autogen.sh
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,8 +5,16 @@ on:
     branches: [ "sf-bug-205-position-01" ]
     
   workflow_dispatch:
-      { }
-
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
 jobs:
   build:
 
@@ -14,6 +22,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    
+    - name: show-env
+      env:
+        EVENT_CONTEXT: ${{ toJSON(github.event) }}
+      run: |
+          echo $EVENT_CONTEXT
     
     - name: autogen
       run: ./autogen.sh

--- a/src/xo-paint.c
+++ b/src/xo-paint.c
@@ -632,9 +632,9 @@ void start_text(GdkEvent *event, struct Item *item)
     item->text = NULL;
     item->canvas_item = NULL;
     item->bbox.left = pt[0];
-    item->bbox.top = pt[1];
+    item->bbox.top = pt[1] - ui.font_size/2;
     item->bbox.right = ui.cur_page->width;
-    item->bbox.bottom = pt[1]+100.;
+    item->bbox.bottom = item->bbox.top + ui.font_size;
     item->font_name = g_strdup(ui.font_name);
     item->font_size = ui.font_size;
     g_memmove(&(item->brush), ui.cur_brush, sizeof(struct Brush));


### PR DESCRIPTION
This is a proposed minimal fix for:
https://sourceforge.net/p/xournal/bugs/205/
by positioning the bounding box around the active spot, rather than below it.

It seems that Pango takes a font size to be from the top to the baseline, excluding the descenders, so the bounding box is not quite right.  I'm hoping that it's updated soon enough in update_item_bbox(), called from end_text().